### PR TITLE
Initial k8s setup

### DIFF
--- a/quick-install/k8s/README.md
+++ b/quick-install/k8s/README.md
@@ -1,0 +1,5 @@
+This is an example of a kubernetes deployment of Semarchy that is pointing to an external-to-the-k8s-cluster postgresql database.
+
+You should supply the secrets in the secrets.yaml file for DB URL and credentials.
+
+nginx-ingress.yaml is for a deployment where your TLS certificates are integrated with vault. Hopefully you can translate this into your specific implementation's use-case if this doesn't work for you.

--- a/quick-install/k8s/deployment.yaml
+++ b/quick-install/k8s/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: semarchyxdm
+  labels:
+    app: semarchyxdm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: semarchyxdm
+  template:
+    metadata:
+      labels:
+        app: semarchyxdm
+    spec:
+      containers:
+      - image: semarchy/xdm:5.3.10
+        imagePullPolicy: Always
+        name: semarchyxdm
+        ports:
+        - containerPort: 8080
+        resources: {}
+        env:
+          - name: XDM_REPOSITORY_DRIVER
+            value: "org.postgresql.Driver"
+          - name: XDM_REPOSITORY_URL
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets
+                key: xdm_repository_url
+          - name: XDM_REPOSITORY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets 
+                key: xdm_repository_username
+          - name: XDM_REPOSITORY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets
+                key: xdm_repository_password
+          - name: XDM_REPOSITORY_READONLY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets
+                key: xdm_repository_readonly_username
+          - name: XDM_REPOSITORY_READONLY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets
+                key: xdm_repository_readonly_password
+          - name: SEMARCHY_SETUP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: semarchysecrets
+                key: semarchy_setup_token
+      restartPolicy: Always
+status: {}

--- a/quick-install/k8s/nginx-ingress.yaml
+++ b/quick-install/k8s/nginx-ingress.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: semarchyxdm
+  namespace: semarchy
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: vault-issuer
+    cert-manager.io/common-name: semarchyxdm.yourcompany.com
+    ingress.kubernetes.io/proxy-body-size: "500m"
+    nginx.org/proxy-connect-timeout: "30s"
+    nginx.org/proxy-read-timeout: "20s"
+    nginx.org/client-max-body-size: "500m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "36000"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "36000"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "36000"
+    nginx.ingress.kubernetes.io/server-snippet: "keepalive_timeout 36000s;client_body_timeout 36000s;client_header_timeout 36000s;"
+    # necessary for uploading XML files greater than 1 megabyte in size
+    nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+spec:
+  rules:
+  - host: semarchyxdm.yourcompany.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+           name: semarchyxdm
+           port: 
+             number: 8080
+  tls:
+  - hosts:
+    - semarchyxdm.yourcompany.com
+    secretName: semarchyxdmingress
+

--- a/quick-install/k8s/secrets.yaml
+++ b/quick-install/k8s/secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: semarchysecrets 
+type: Opaque
+data:
+  xdm_repository_url: 
+  xdm_repository_username:  
+  xdm_repository_password:  
+  xdm_repository_readonly_username: 
+  xdm_repository_readonly_password:  
+  semarchy_setup_token:  
+  
+

--- a/quick-install/k8s/service.yaml
+++ b/quick-install/k8s/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: semarchyxdm
+spec:
+  ports:
+  - name: default
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: semarchyxdm
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This is an example of a kubernetes setup for Semarchy pointing to an external postgresql database. I've also included an nginx file with the necessary nginx.ingress.kubernetes.io/proxy-body-size annotation to allow for XML file uploads greater than the default of (I believe) 1 megabyte. This is working in our POC environment.